### PR TITLE
Correction for Paper 250's title

### DIFF
--- a/UAI2023.bib
+++ b/UAI2023.bib
@@ -882,7 +882,7 @@
 	author = {Liu, Ao and Han, Qishen and Xia, Lirong and Yu, Nengkun},
 	openreview = {JAW9F2zzP7},
 	pages = {1274-1283},
-	title = {Accelerating Majority Voting by Quantum Computation}}
+	title = {Accelerating Voting by Quantum Computation}}
 
 @inproceedings{liu23b,
 	abstract = {Neural networks are universal approximators and are studied for their use in solving differential equations.  However, a major criticism is the lack of error bounds for obtained solutions.  This paper proposes a technique to rigorously evaluate the error bound of Physics-Informed Neural Networks (PINNs) on most linear ordinary differential equations (ODEs), certain nonlinear ODEs, and first-order linear partial differential equations (PDEs).  The error bound is based purely on equation structure and residual information and does not depend on assumptions of how well the networks are trained.  We propose algorithms that bound the error efficiently. Some proposed algorithms provide tighter bounds than others at the cost of longer run time.},

--- a/_posts/2023-07-02-liu23a.md
+++ b/_posts/2023-07-02-liu23a.md
@@ -14,14 +14,14 @@ abstract: 'Studying the computational complexity and designing fast algorithms f
   time under a large class of voting rules. Our theoretical results are supported
   by experiments under plurality, Borda, Copeland, and STV.'
 openreview: JAW9F2zzP7
-title: Accelerating Majority Voting by Quantum Computation
+title: Accelerating Voting by Quantum Computation
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR
 issn: 2640-3498
 id: liu23a
 month: 0
-tex_title: Accelerating Majority Voting by Quantum Computation
+tex_title: Accelerating Voting by Quantum Computation
 firstpage: 1274
 lastpage: 1283
 page: 1274-1283


### PR DESCRIPTION
The correct title should be Accelerating Voting by Quantum Computation (the title on Openreview) instead of Accelerating Majority Voting by Quantum Computation as shown on the website.