### PR TITLE
Corrected typo in author name

### DIFF
--- a/_posts/2023-07-02-de-smet23a.md
+++ b/_posts/2023-07-02-de-smet23a.md
@@ -42,7 +42,7 @@ author:
 - given: Angelika
   family: Kimmig
 - given: Luc
-  family: De Readt
+  family: De Raedt
 date: 2023-07-02
 address:
 container-title: Proceedings of the Thirty-Ninth Conference on Uncertainty in Artificial

--- a/_posts/2023-07-02-de-smet23a.md
+++ b/_posts/2023-07-02-de-smet23a.md
@@ -29,7 +29,7 @@ page: 529-538
 order: 529
 cycles: false
 bibtex_author: De Smet, Lennert and Zuidberg Dos Martires, Pedro and Manhaeve, Robin
-  and Marra, Giuseppe and Kimmig, Angelika and De Readt, Luc
+  and Marra, Giuseppe and Kimmig, Angelika and De Raedt, Luc
 author:
 - given: Lennert
   family: De Smet


### PR DESCRIPTION
Dear

I am the corresponding (first) author of this paper and noticed that the surname of the last author, Luc De Raedt, contains a typo. Consequently, this publication has an incorrect citation entry and it is not linked as a publication of Luc De Raedt on Google Scholar and other platforms. 

Please remedy this typo such that this paper obtains a correct citation.

Kind regards,
Lennert De Smet